### PR TITLE
fix(scroll-list): pass scrollPosition to allow controlled scroll calculation

### DIFF
--- a/packages/components/src/data-grid/data-grid.tsx
+++ b/packages/components/src/data-grid/data-grid.tsx
@@ -47,7 +47,7 @@ export function DataGrid<T, EL extends HTMLElement>({
     const scrollListRef = useRef<HTMLDivElement>(null);
     // const headerSize = useElementDimension(headerRef, isHorizontal, true);
     const [columnSizes, updateColumnSizes] = useStateControls(columnSizesControl, []);
-    const listHorizontalScroll = useScroll(true, scrollListRef);
+    const listHorizontalScroll = useScroll(true, scrollListRef.current);
     const listeners = useRef(new Set<{ cb: (ev: MouseEvent) => void; eventName: keyof WindowEventMap }>());
     const contextValue = useMemo(
         () => ({

--- a/packages/components/src/data-grid/data-grid.tsx
+++ b/packages/components/src/data-grid/data-grid.tsx
@@ -47,7 +47,7 @@ export function DataGrid<T, EL extends HTMLElement>({
     const scrollListRef = useRef<HTMLDivElement>(null);
     // const headerSize = useElementDimension(headerRef, isHorizontal, true);
     const [columnSizes, updateColumnSizes] = useStateControls(columnSizesControl, []);
-    const listHorizontalScroll = useScroll(true, scrollListRef.current);
+    const listHorizontalScroll = useScroll({ isHorizontal: true, ref: scrollListRef });
     const listeners = useRef(new Set<{ cb: (ev: MouseEvent) => void; eventName: keyof WindowEventMap }>());
     const contextValue = useMemo(
         () => ({

--- a/packages/components/src/hooks/simulations/use-element-rect/element-rect-hook-simulator.tsx
+++ b/packages/components/src/hooks/simulations/use-element-rect/element-rect-hook-simulator.tsx
@@ -32,7 +32,7 @@ export const ElmentDimHookSimulator: React.FC<{
     height?: string;
 }> = ({ isVertical, watchSize, width, height }) => {
     const ref = useRef<HTMLDivElement>(null);
-    const res = useElementDimension(ref, isVertical, watchSize);
+    const res = useElementDimension(ref.current, isVertical, watchSize);
 
     const [size, updateSize] = useState('100');
     const usedSize = isNaN(parseInt(size)) ? 100 : parseInt(size);
@@ -51,7 +51,7 @@ export const ElmentDimHookSimulator: React.FC<{
             <div ref={ref} style={{ width: '100%', height: usedSize + 'px', background: 'lightblue' }}>
                 <div style={{ position: 'fixed', top: '50%', left: '50%' }}>{res}</div>
             </div>
-        </div >
+        </div>
     );
 };
 

--- a/packages/components/src/hooks/simulations/use-scroll/scroll-hook-simulator.tsx
+++ b/packages/components/src/hooks/simulations/use-scroll/scroll-hook-simulator.tsx
@@ -7,7 +7,7 @@ export const ScrollHookSimulator: React.FC<{
     useWindowScroll?: boolean;
 }> = ({ isHorizontal = false, useWindowScroll = true }) => {
     const ref = useRef<HTMLDivElement>(null);
-    const res = useScroll(isHorizontal, useWindowScroll ? undefined : ref);
+    const res = useScroll(isHorizontal, useWindowScroll ? undefined : ref.current);
     return useWindowScroll ? (
         <div>
             <div style={{ position: 'fixed', top: '50%', left: '50%' }} id="res">

--- a/packages/components/src/hooks/simulations/use-scroll/scroll-hook-simulator.tsx
+++ b/packages/components/src/hooks/simulations/use-scroll/scroll-hook-simulator.tsx
@@ -7,7 +7,7 @@ export const ScrollHookSimulator: React.FC<{
     useWindowScroll?: boolean;
 }> = ({ isHorizontal = false, useWindowScroll = true }) => {
     const ref = useRef<HTMLDivElement>(null);
-    const res = useScroll(isHorizontal, useWindowScroll ? undefined : ref.current);
+    const res = useScroll({ isHorizontal, ref: useWindowScroll ? undefined : ref });
     return useWindowScroll ? (
         <div>
             <div style={{ position: 'fixed', top: '50%', left: '50%' }} id="res">

--- a/packages/components/src/hooks/use-scroll.ts
+++ b/packages/components/src/hooks/use-scroll.ts
@@ -2,21 +2,32 @@ import { useLayoutEffect } from 'react';
 import { useDelayedUpdate } from './use-delayed-update';
 
 /** if ref is not supplied use scroll will return the window scroll */
-export const useScroll = (isHorizontal?: boolean, ref?: HTMLElement | null): number => {
+export const useScroll = ({
+    isHorizontal,
+    ref,
+    disabled = false,
+}: {
+    isHorizontal?: boolean;
+    disabled?: boolean;
+    ref?: React.RefObject<HTMLElement>;
+}): number => {
     const trigger = useDelayedUpdate();
 
     useLayoutEffect(() => {
-        const target = ref ? ref : typeof window !== 'undefined' ? window : undefined;
-        target?.addEventListener('scroll', trigger);
-        return () => {
-            target?.removeEventListener('scroll', trigger);
-        };
-    }, [ref, trigger]);
-    if (!ref) {
+        if (!disabled) {
+            const target = ref?.current ? ref.current : typeof window !== 'undefined' ? window : undefined;
+
+            target?.addEventListener('scroll', trigger);
+            return () => target?.removeEventListener('scroll', trigger);
+        }
+        return;
+    }, [disabled, ref, trigger]);
+
+    if (!ref?.current) {
         if (typeof window === 'undefined') {
             return 0;
         }
         return isHorizontal ? window.scrollX : window.scrollY;
     }
-    return (isHorizontal ? ref.scrollLeft : ref.scrollTop) || 0;
+    return (isHorizontal ? ref.current.scrollLeft : ref.current.scrollTop) || 0;
 };

--- a/packages/components/src/hooks/use-scroll.ts
+++ b/packages/components/src/hooks/use-scroll.ts
@@ -1,13 +1,12 @@
-import type React from 'react';
 import { useLayoutEffect } from 'react';
 import { useDelayedUpdate } from './use-delayed-update';
 
 /** if ref is not supplied use scroll will return the window scroll */
-export const useScroll = (isHorizontal?: boolean, ref?: React.RefObject<HTMLElement>): number => {
+export const useScroll = (isHorizontal?: boolean, ref?: HTMLElement | null): number => {
     const trigger = useDelayedUpdate();
 
     useLayoutEffect(() => {
-        const target = ref ? ref.current : typeof window !== 'undefined' ? window : undefined;
+        const target = ref ? ref : typeof window !== 'undefined' ? window : undefined;
         target?.addEventListener('scroll', trigger);
         return () => {
             target?.removeEventListener('scroll', trigger);
@@ -19,5 +18,5 @@ export const useScroll = (isHorizontal?: boolean, ref?: React.RefObject<HTMLElem
         }
         return isHorizontal ? window.scrollX : window.scrollY;
     }
-    return (isHorizontal ? ref.current?.scrollLeft : ref.current?.scrollTop) || 0;
+    return (isHorizontal ? ref.scrollLeft : ref.scrollTop) || 0;
 };

--- a/packages/components/src/scroll-list/scroll-list.tsx
+++ b/packages/components/src/scroll-list/scroll-list.tsx
@@ -170,8 +170,8 @@ export function ScrollList<T, EL extends HTMLElement = HTMLDivElement>({
 }: ScrollListProps<T, EL>): JSX.Element {
     const defaultListRef = useRef<HTMLElement>(null);
     const listRef = (listRoot?.props?.ref as React.RefObject<HTMLDivElement>) || defaultListRef;
-    const scrollWindowSize = useElementDimension(scrollWindow, !isHorizontal, watchScrollWindoSize);
-    const currentScroll = useScroll(isHorizontal, scrollWindow);
+    const scrollWindowSize = useElementDimension(scrollWindow?.current, !isHorizontal, watchScrollWindoSize);
+    const currentScroll = useScroll(isHorizontal, scrollWindow?.current);
     const lastRenderedItem = useRef({
         items,
         last: 0,

--- a/packages/components/src/scroll-list/scroll-list.tsx
+++ b/packages/components/src/scroll-list/scroll-list.tsx
@@ -137,6 +137,10 @@ export interface ScrollListProps<T, EL extends HTMLElement> extends ListProps<T>
      */
     scrollListRoot?: typeof scrollListRoot;
 
+    /**
+     * sets a custom scroll position instead of watching container's scroll event
+     */
+    scrollPosition?: number;
     itemsInRow?: number;
     itemGap?: number;
     listRoot?: typeof listRoot;
@@ -167,11 +171,13 @@ export function ScrollList<T, EL extends HTMLElement = HTMLDivElement>({
     itemsInRow = 1,
     transmitKeyPress,
     overlay,
+    scrollPosition,
 }: ScrollListProps<T, EL>): JSX.Element {
     const defaultListRef = useRef<HTMLElement>(null);
     const listRef = (listRoot?.props?.ref as React.RefObject<HTMLDivElement>) || defaultListRef;
     const scrollWindowSize = useElementDimension(scrollWindow?.current, !isHorizontal, watchScrollWindoSize);
-    const currentScroll = useScroll(isHorizontal, scrollWindow?.current);
+    const currentScroll = useScroll({ isHorizontal, ref: scrollWindow, disabled: scrollPosition !== undefined });
+    const resolvedScroll = scrollPosition ?? currentScroll;
     const lastRenderedItem = useRef({
         items,
         last: 0,
@@ -225,9 +231,9 @@ export function ScrollList<T, EL extends HTMLElement = HTMLDivElement>({
 
     const calcScrollPosition = () => {
         const firstWantedPixel = unmountItems
-            ? Math.max(currentScroll - scrollWindowSize * extraRenderedItems - initialScrollOffset, 0)
+            ? Math.max(resolvedScroll - scrollWindowSize * extraRenderedItems - initialScrollOffset, 0)
             : 0;
-        const lastWantedPixel = scrollWindowSize * (1 + extraRenderedItems) + currentScroll - initialScrollOffset;
+        const lastWantedPixel = scrollWindowSize * (1 + extraRenderedItems) + resolvedScroll - initialScrollOffset;
 
         if (typeof itemSize === 'number') {
             let endIdx = Math.ceil(lastWantedPixel / itemSize);

--- a/packages/components/src/scroll-list/simulations/scroll-list-with-scroll-position.board.tsx
+++ b/packages/components/src/scroll-list/simulations/scroll-list-with-scroll-position.board.tsx
@@ -1,13 +1,5 @@
 import React, { useState } from 'react';
 import { ItemData, ItemRenderer } from '../../simulation-assets/item-renderer';
-import {
-    clickAction,
-    expectElementsStyle,
-    expectElementStyle,
-    hoverAction,
-    scenarioMixin,
-    scrollAction,
-} from '../../simulation-mixins/scenario';
 import { ScrollList } from '../scroll-list';
 import { mixinProjectThemes } from '../../simulation-mixins/mixin-project-themes';
 import { createBoard } from '@wixc3/react-board';
@@ -57,32 +49,5 @@ export default createBoard({
         windowHeight: 300,
         windowWidth: 600,
     },
-    plugins: [
-        scenarioMixin.use({
-            skip: true,
-            events: [
-                hoverAction('[data-id="a8"]'),
-                expectElementStyle('[data-id="a8"]', {
-                    color: 'rgb(0, 0, 255)',
-                }),
-                hoverAction('[data-id="a9"]'),
-                expectElementsStyle({
-                    '[data-id="a8"]': {
-                        color: 'rgb(0, 0, 0)',
-                    },
-                    '[data-id="a9"]': {
-                        color: 'rgb(0, 0, 255)',
-                    },
-                }),
-                clickAction('[data-id="a9"]'),
-                expectElementStyle('[data-id="a9"]', {
-                    backgroundColor: 'rgb(0, 0, 255)',
-                }),
-                clickAction('[data-id="a11"]'),
-                scrollAction(-1),
-                scrollAction(0),
-            ],
-        }),
-        mixinProjectThemes,
-    ],
+    plugins: [mixinProjectThemes],
 });

--- a/packages/components/src/scroll-list/simulations/scroll-list-with-scroll-position.board.tsx
+++ b/packages/components/src/scroll-list/simulations/scroll-list-with-scroll-position.board.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { ItemData, ItemRenderer } from '../../simulation-assets/item-renderer';
+import {
+    clickAction,
+    expectElementsStyle,
+    expectElementStyle,
+    hoverAction,
+    scenarioMixin,
+    scrollAction,
+} from '../../simulation-mixins/scenario';
+import { ScrollList } from '../scroll-list';
+import { mixinProjectThemes } from '../../simulation-mixins/mixin-project-themes';
+import { createBoard } from '@wixc3/react-board';
+
+const items = new Array(1000).fill(0).map(
+    (_, idx) =>
+        ({
+            id: 'a' + idx,
+            title: 'item number ' + idx,
+        } as ItemData)
+);
+
+export default createBoard({
+    name: 'ScrollList with scrollPosition',
+    Board: () => {
+        const [scrollPosition, setScrollPosition] = useState(0);
+
+        const handleScroll: React.UIEventHandler<HTMLDivElement> = (e) => {
+            setScrollPosition((e.target as HTMLDivElement).scrollTop);
+        };
+
+        return (
+            <div style={{ height: '250px', overflow: 'auto' }} onScroll={handleScroll}>
+                <ScrollList
+                    scrollPosition={scrollPosition}
+                    ItemRenderer={ItemRenderer}
+                    items={items}
+                    getId={(item: ItemData) => item.id}
+                    watchScrollWindoSize={true}
+                    listRoot={{
+                        el: 'div',
+                        props: {
+                            style: {
+                                display: 'grid',
+                                gridTemplateColumns: '1fr',
+                                gridGap: '20px',
+                            },
+                        },
+                    }}
+                    itemGap={20}
+                />
+            </div>
+        );
+    },
+    environmentProps: {
+        canvasWidth: 560,
+        windowHeight: 300,
+        windowWidth: 600,
+    },
+    plugins: [
+        scenarioMixin.use({
+            skip: true,
+            events: [
+                hoverAction('[data-id="a8"]'),
+                expectElementStyle('[data-id="a8"]', {
+                    color: 'rgb(0, 0, 255)',
+                }),
+                hoverAction('[data-id="a9"]'),
+                expectElementsStyle({
+                    '[data-id="a8"]': {
+                        color: 'rgb(0, 0, 0)',
+                    },
+                    '[data-id="a9"]': {
+                        color: 'rgb(0, 0, 255)',
+                    },
+                }),
+                clickAction('[data-id="a9"]'),
+                expectElementStyle('[data-id="a9"]', {
+                    backgroundColor: 'rgb(0, 0, 255)',
+                }),
+                clickAction('[data-id="a11"]'),
+                scrollAction(-1),
+                scrollAction(0),
+            ],
+        }),
+        mixinProjectThemes,
+    ],
+});


### PR DESCRIPTION
Currently, `scrollList` uses `useScroll` that adds a "scroll" event listener to the container and updates when it fires.
When the scroll position of the parent element gets changed programmatically (for example, changing `scrollTop`), this calculation is not executed.
This PR adds the functionality to support custom `scrollPosition` passed as a prop to the `scrollList` component.