### PR TITLE
fix(scroll-list): use 0 size when specified

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.1.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylable-components",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React components that use Stylable.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/components/src/scroll-list/scroll-list.tsx
+++ b/packages/components/src/scroll-list/scroll-list.tsx
@@ -255,7 +255,7 @@ export function ScrollList<T, EL extends HTMLElement = HTMLDivElement>({
 
             for (let z = 0; z < itemsInRow && z + i < items.length; z++) {
                 const id = getId(items[i + z]!);
-                const itemSize = (isHorizontal ? sizes[id]?.width : sizes[id]?.height) || avgSize;
+                const itemSize = (isHorizontal ? sizes[id]?.width : sizes[id]?.height) ?? avgSize;
                 itemMaxSize = Math.max(itemMaxSize, itemSize);
             }
             taken += itemMaxSize + itemGap;


### PR DESCRIPTION
If the user specifies 0, use it, otherwise use `avgSize`