### PR TITLE
refactor(scroll-list): fix typo in property name

### DIFF
--- a/packages/components/src/data-grid/data-grid.tsx
+++ b/packages/components/src/data-grid/data-grid.tsx
@@ -125,7 +125,7 @@ export function DataGrid<T, EL extends HTMLElement>({
                     })}
                     isHorizontal={isHorizontal}
                     scrollWindow={scrollListRef}
-                    watchScrollWindoSize={true}
+                    watchScrollWindowSize={true}
                     // initialScrollOffset={headerSize}
                 />
             </GridRoot>

--- a/packages/components/src/scroll-list/scroll-list.tsx
+++ b/packages/components/src/scroll-list/scroll-list.tsx
@@ -71,7 +71,7 @@ export interface ScrollListProps<T, EL extends HTMLElement> extends ListProps<T>
      *   true: measure on changes,
      *   number: use the number as size
      */
-    watchScrollWindoSize?: number | boolean;
+    watchScrollWindowSize?: number | boolean;
     /**
      * Scroll offset for initial render.
      *
@@ -151,7 +151,7 @@ export function ScrollList<T, EL extends HTMLElement = HTMLDivElement>({
     items,
     isHorizontal = false,
     scrollWindow,
-    watchScrollWindoSize,
+    watchScrollWindowSize,
     itemCount,
     getId,
     ItemRenderer,
@@ -175,7 +175,7 @@ export function ScrollList<T, EL extends HTMLElement = HTMLDivElement>({
 }: ScrollListProps<T, EL>): JSX.Element {
     const defaultListRef = useRef<HTMLElement>(null);
     const listRef = (listRoot?.props?.ref as React.RefObject<HTMLDivElement>) || defaultListRef;
-    const scrollWindowSize = useElementDimension(scrollWindow, !isHorizontal, watchScrollWindoSize);
+    const scrollWindowSize = useElementDimension(scrollWindow, !isHorizontal, watchScrollWindowSize);
     const currentScroll = useScroll({ isHorizontal, ref: scrollWindow, disabled: scrollPosition !== undefined });
     const resolvedScroll = scrollPosition ?? currentScroll;
     const lastRenderedItem = useRef({

--- a/packages/components/src/scroll-list/simulations/element-scroll-items-change-size.board.tsx
+++ b/packages/components/src/scroll-list/simulations/element-scroll-items-change-size.board.tsx
@@ -39,7 +39,7 @@ export default createBoard({
             ItemRenderer={ItemRenderer}
             items={items}
             getId={(item: ItemData) => item.id}
-            watchScrollWindoSize={true}
+            watchScrollWindowSize={true}
             listRoot={{
                 el: 'div',
                 props: {

--- a/packages/components/src/scroll-list/simulations/element-scroll.board.tsx
+++ b/packages/components/src/scroll-list/simulations/element-scroll.board.tsx
@@ -29,7 +29,7 @@ export default createBoard({
             ItemRenderer={ItemRenderer}
             items={items}
             getId={(item: ItemData) => item.id}
-            watchScrollWindoSize={true}
+            watchScrollWindowSize={true}
             listRoot={{
                 el: 'div',
                 props: {

--- a/packages/components/src/scroll-list/simulations/many-in-row.board.tsx
+++ b/packages/components/src/scroll-list/simulations/many-in-row.board.tsx
@@ -27,7 +27,7 @@ export default createBoard({
             ItemRenderer={ItemRenderer}
             items={items}
             getId={(item: ItemData) => item.id}
-            watchScrollWindoSize={true}
+            watchScrollWindowSize={true}
             listRoot={{
                 props: {
                     style: {

--- a/packages/components/src/scroll-list/simulations/no-unmount.board.tsx
+++ b/packages/components/src/scroll-list/simulations/no-unmount.board.tsx
@@ -28,7 +28,7 @@ export default createBoard({
             ItemRenderer={StatefullItemRenderer}
             items={items}
             getId={(item: ItemData) => item.id}
-            watchScrollWindoSize={true}
+            watchScrollWindowSize={true}
             unmountItems={false}
         />
     ),

--- a/packages/components/src/scroll-list/simulations/scroll-list-add-more.board.tsx
+++ b/packages/components/src/scroll-list/simulations/scroll-list-add-more.board.tsx
@@ -30,7 +30,7 @@ export default createBoard({
                 items={items}
                 getId={(item: ItemData) => item.id}
                 itemCount={-1}
-                watchScrollWindoSize={true}
+                watchScrollWindowSize={true}
                 loadMore={loadMore}
                 loadingState={loadingState}
             />

--- a/packages/components/src/scroll-list/simulations/scroll-list-with-scroll-position.board.tsx
+++ b/packages/components/src/scroll-list/simulations/scroll-list-with-scroll-position.board.tsx
@@ -28,7 +28,7 @@ export default createBoard({
                     ItemRenderer={ItemRenderer}
                     items={items}
                     getId={(item: ItemData) => item.id}
-                    watchScrollWindoSize={true}
+                    watchScrollWindowSize={true}
                     listRoot={{
                         el: 'div',
                         props: {

--- a/packages/components/src/scroll-list/simulations/scroll-list.board.tsx
+++ b/packages/components/src/scroll-list/simulations/scroll-list.board.tsx
@@ -27,7 +27,7 @@ export default createBoard({
             ItemRenderer={ItemRenderer}
             items={items}
             getId={(item: ItemData) => item.id}
-            watchScrollWindoSize={true}
+            watchScrollWindowSize={true}
             listRoot={{
                 el: 'div',
                 props: {


### PR DESCRIPTION
I'm not sure how to deal with such changes — do it in backward-compatible way, or just fix usages accordingly?