### PR TITLE
feature(scroll-list): improve scroll to selection, and turn it off by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
     "source-map-loader": "^4.0.1",
+    "scroll-into-view-if-needed": "^2.2.29",
     "typescript": "~4.8.4",
     "util": "^0.12.5",
     "webpack": "^5.74.0",

--- a/packages/components/src/scroll-list/boards/scroll-to-selection.board.tsx
+++ b/packages/components/src/scroll-list/boards/scroll-to-selection.board.tsx
@@ -74,6 +74,7 @@ export default createBoard({
                     itemSize={() => 50}
                     getId={getId}
                     selectionControl={[selectedItem, noop]}
+                    scrollToSelection={true}
                     scrollListRoot={{
                         el: 'div',
                         props: {

--- a/packages/components/src/scroll-list/hooks/use-scroll-list-scroll-to-selected.ts
+++ b/packages/components/src/scroll-list/hooks/use-scroll-list-scroll-to-selected.ts
@@ -4,6 +4,7 @@ import type { ListProps } from '../../list/list';
 import type { ScrollListProps } from '../../scroll-list/scroll-list';
 
 export const useScrollListScrollToSelected = <T, EL extends HTMLElement>({
+    scrollToSelection,
     scrollWindow,
     scrollListRef,
     items,
@@ -16,6 +17,7 @@ export const useScrollListScrollToSelected = <T, EL extends HTMLElement>({
     extraRenderSize,
     scrollWindowSize,
 }: {
+    scrollToSelection: boolean;
     scrollWindow?: ScrollListProps<T, EL>['scrollWindow'];
     scrollListRef: RefObject<EL>;
     items: ListProps<T>['items'];
@@ -101,7 +103,12 @@ export const useScrollListScrollToSelected = <T, EL extends HTMLElement>({
     );
 
     useEffect(() => {
-        if (selectedIndex > -1 && !isScrollingToSelection.current && mountedItems.current.size > 0) {
+        if (
+            scrollToSelection &&
+            selectedIndex > -1 &&
+            mountedItems.current.size > 0 &&
+            !isScrollingToSelection.current
+        ) {
             isScrollingToSelection.current = true;
 
             scrollTo(selectedIndex);
@@ -110,5 +117,5 @@ export const useScrollListScrollToSelected = <T, EL extends HTMLElement>({
         return () => {
             cleanUp();
         };
-    }, [mountedItems, scrollTo, selectedIndex]);
+    }, [scrollToSelection, mountedItems, scrollTo, selectedIndex]);
 };

--- a/packages/components/src/scroll-list/hooks/use-scroll-list-scroll-to-selected.ts
+++ b/packages/components/src/scroll-list/hooks/use-scroll-list-scroll-to-selected.ts
@@ -85,9 +85,9 @@ export const useScrollListScrollToSelected = <T, EL extends HTMLElement>({
             };
 
             const scrollTarget = scrollWindow?.current ?? window;
-            const mount = [...mountedItems.current];
-            const firstIndex = items.findIndex((i) => getId(i) === mount[0]);
-            const lastIndex = items.findIndex((i) => getId(i) === mount[mount.length - 1]);
+            const mountedIndexes = [...mountedItems.current].map((id) => items.findIndex((i) => getId(i) === id));
+            const firstIndex = Math.min(...mountedIndexes);
+            const lastIndex = Math.max(...mountedIndexes);
 
             if (selectedIndex < firstIndex) {
                 scrollTarget.scrollBy({ top: calculateDistance({ itemIndex: firstIndex, direction: 'up' }) });

--- a/packages/components/src/scroll-list/scroll-list.tsx
+++ b/packages/components/src/scroll-list/scroll-list.tsx
@@ -124,6 +124,12 @@ export interface ScrollListProps<T, EL extends HTMLElement, I extends ScrollList
      * allows replacing the root element of the scroll list
      */
     scrollListRoot?: typeof scrollListRoot;
+    /**
+     * allows turning on scroll to selection behaviour
+     *
+     * @default false
+     */
+    scrollToSelection?: boolean;
     itemsInRow?: number;
     itemGap?: number;
     /**
@@ -151,6 +157,7 @@ export function ScrollList<T, EL extends HTMLElement = HTMLDivElement>({
     scrollListRoot,
     listRoot,
     selectionControl,
+    scrollToSelection = false,
     extraRenderSize = 0.5,
     unmountItems,
     preloader,
@@ -269,6 +276,7 @@ export function ScrollList<T, EL extends HTMLElement = HTMLDivElement>({
     useScrollListScrollToSelected({
         scrollWindow,
         scrollListRef,
+        scrollToSelection,
         items,
         getId,
         selected,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,6 +2551,11 @@ compression@^1.7.4:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
+compute-scroll-into-view@^1.0.17:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz#6a88f18acd9d42e9cf4baa6bec7e0522607ab7ab"
+  integrity sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -6454,6 +6459,13 @@ schema-utils@^4.0.0:
     ajv "^8.8.0"
     ajv-formats "^2.1.1"
     ajv-keywords "^5.0.0"
+
+scroll-into-view-if-needed@^2.2.29:
+  version "2.2.29"
+  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz#551791a84b7e2287706511f8c68161e4990ab885"
+  integrity sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==
+  dependencies:
+    compute-scroll-into-view "^1.0.17"
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Added prop to control if scrolling to selection is enabled.

Improve UX by using the `scroll-into-view-if-needed` package and changing positioning principles: previously, it was always centered; now, if it's not repeated scrolling (we got in place the first time), we choose 'start' or 'end' based on the direction of scrolling; if we didn't need to scroll, 'nearest' position. If it's repeated scrolling, the direction is considered lost, and 'center' is used.


Also, fixed excessive scrolls caused by incorrect mounted items indexes calculation — previously order was assumed, now it's being done by using min and max indexes, which should be bulletproof. 
