### PR TITLE
fix: really check if node exist

### DIFF
--- a/packages/components/src/scroll-list/hooks/use-scroll-list-scroll-to-selected.ts
+++ b/packages/components/src/scroll-list/hooks/use-scroll-list-scroll-to-selected.ts
@@ -76,12 +76,12 @@ export const useScrollListScrollToSelected = <T, EL extends HTMLElement>({
 
             const scrollIntoView = (selected: number, position: ScrollLogicalPosition) => {
                 const node = scrollListRef.current?.querySelector(`[data-id='${getId(items[selected]!)}']`);
-                if (node === null) {
+                if (!node) {
                     timeout.current = window.setTimeout(
                         () => isScrollingToSelection.current && scrollTo(selected, true)
                     );
                 } else {
-                    scrollIntoViewIfNeeded(node!, {
+                    scrollIntoViewIfNeeded(node, {
                         scrollMode: 'if-needed',
                         block: position,
                         inline: position,


### PR DESCRIPTION
Since we scroll after timeout it can be that the `scrollListRef.current` is undefined if component is unmounted during this time.

The check for explicit `null` was not enough so `node!` was a lie.  

This should fixes the `isConnected` flaky tests. 