### PR TITLE
fix(use-position): check whether an element is rendered before getting its position

### DIFF
--- a/packages/components/src/hooks/use-position.ts
+++ b/packages/components/src/hooks/use-position.ts
@@ -45,6 +45,9 @@ export const usePositionInParent = (
     const watch: Watch = typeof watchPosition === 'object' ? 'ignore' : watchPosition ? 'timer' : 'measure-once';
     const lastValRef = useRef<Position>();
     const onTimer = useCallback((el: HTMLElement) => {
+        if (!el || !el.parentElement) {
+            return unchanged;
+        }
         const res = getItemPositionInParent(el);
         if (lastValRef.current && isSamePosition(res, lastValRef.current)) {
             return unchanged;


### PR DESCRIPTION
`usePositionInParent` blows up when it tries to get the boundingClientRect of an unmounted element.  