### PR TITLE
chore: enable experimental selector inference

### DIFF
--- a/stylable.config.js
+++ b/stylable.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    defaultConfig() {
+        return {
+            experimentalSelectorInference: true,
+        };
+    },
+};


### PR DESCRIPTION
This PR enables the stylable `experimentalSelectorInference` as preparation for stylable 6 which