### PR TITLE
fix(hooks): remove canvas properties from board files

### DIFF
--- a/packages/components/src/hooks/boards/use-scroll/use-scroll-horizontal-window.board.tsx
+++ b/packages/components/src/hooks/boards/use-scroll/use-scroll-horizontal-window.board.tsx
@@ -7,7 +7,7 @@ import { ScrollHookSimulator } from './scroll-hook-simulator';
 export default createBoard({
     name: 'use scroll window horizontal',
     Board: () => (
-        <div style={{ height: '200px', width: '2000px' }}>
+        <div style={{ height: '500px', width: '2000px' }}>
             <ScrollHookSimulator isHorizontal={true} />
         </div>
     ),

--- a/packages/components/src/hooks/boards/use-scroll/use-scroll-horizontal-window.board.tsx
+++ b/packages/components/src/hooks/boards/use-scroll/use-scroll-horizontal-window.board.tsx
@@ -6,10 +6,12 @@ import { ScrollHookSimulator } from './scroll-hook-simulator';
 
 export default createBoard({
     name: 'use scroll window horizontal',
-    Board: () => <ScrollHookSimulator isHorizontal={true} />,
+    Board: () => (
+        <div style={{ height: '200px', width: '2000px' }}>
+            <ScrollHookSimulator isHorizontal={true} />
+        </div>
+    ),
     environmentProps: {
-        canvasWidth: 2000,
-        canvasHeight: 500,
         windowWidth: 500,
         windowHeight: 640,
     },

--- a/packages/components/src/hooks/boards/use-scroll/use-scroll-vertical-window.board.tsx
+++ b/packages/components/src/hooks/boards/use-scroll/use-scroll-vertical-window.board.tsx
@@ -5,11 +5,13 @@ import { expectElement, expectElementText, maxScroll, scenarioPlugin, scrollActi
 import { ScrollHookSimulator } from './scroll-hook-simulator';
 
 export default createBoard({
-    Board: () => <ScrollHookSimulator />,
     name: 'use scroll window vertical',
+    Board: () => (
+        <div style={{ width: '200px', height: '2000px' }}>
+            <ScrollHookSimulator />
+        </div>
+    ),
     environmentProps: {
-        canvasWidth: 200,
-        canvasHeight: 2000,
         windowWidth: 500,
         windowHeight: 640,
     },


### PR DESCRIPTION
Simulate the scroll behavior using a div element instead of the canvas.