### PR TITLE
fix: tree keyboard focus

### DIFF
--- a/packages/components/src/board-assets/tree-items/tree-item-renderer.st.css
+++ b/packages/components/src/board-assets/tree-items/tree-item-renderer.st.css
@@ -10,6 +10,10 @@
     height: 24px;
 }
 
+.root:hover {
+    color: purple;
+}
+
 .root:focused {
     color: blue
 }

--- a/packages/components/src/board-index.ts
+++ b/packages/components/src/board-index.ts
@@ -4,8 +4,12 @@
  * generated at 'build-board-index.js'
  * do no edit manually
  */
+import scenario_renderer from './_codux/boards/scenario-renderer/scenario-renderer.board';
+import use_element_size from './_codux/boards/hooks/use-element-size/use-element-size.board';
 import tree from './tree/boards/tree.board';
 import tree_with_lanes from './tree/boards/tree-with-lanes.board';
+import tree_keyboard from './tree/boards/tree-keyboard.board';
+import tree_focus from './tree/boards/tree-focus.board';
 import searchable_text from './searchable-text/boards/searchable-text.board';
 import with_header from './scroll-list/boards/with-header.board';
 import scroll_to_selection from './scroll-list/boards/scroll-to-selection.board';
@@ -34,12 +38,14 @@ import button_with_icons from './button/boards/button-with-icons.board';
 import button_with_icon from './button/boards/button-with-icon.board';
 import auto_complete from './auto-complete/auto-complete.board';
 import area from './area/boards/area.board';
-import scenario_renderer from './_codux/boards/scenario-renderer/scenario-renderer.board';
-import use_element_size from './_codux/boards/hooks/use-element-size/use-element-size.board';
 
 export default [
+    scenario_renderer,
+    use_element_size,
     tree,
     tree_with_lanes,
+    tree_keyboard,
+    tree_focus,
     searchable_text,
     with_header,
     scroll_to_selection,
@@ -68,6 +74,4 @@ export default [
     button_with_icon,
     auto_complete,
     area,
-    scenario_renderer,
-    use_element_size,
 ];

--- a/packages/components/src/board-plugins/scenario-plugin/scenario-plugin.tsx
+++ b/packages/components/src/board-plugins/scenario-plugin/scenario-plugin.tsx
@@ -241,6 +241,24 @@ export const scrollAction = (pos: number, isVertical = true, selector?: string, 
     };
 };
 
+export const focusAction = (selector: string) => {
+    return {
+        title: `focus ${selector}`,
+        execute: () => {
+            const target = document.querySelector(selector);
+            if (!target) {
+                throw new Error(`could not find ${selector}`);
+            }
+            if (!('focus' in target) || typeof target.focus !== 'function') {
+                throw new Error('element is not focusable');
+            }
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            target.focus();
+        },
+        timeout: 1000,
+    };
+};
+
 export const hoverAction = (selector?: string, timeout = 2_000): Action => {
     return {
         title: 'Hover ' + (selector || 'window'),
@@ -288,6 +306,28 @@ export const clickAction = (selector?: string, timeout = 2_000): Action => {
         },
         highlightSelector: selector,
         timeout,
+    };
+};
+
+export const keyDownAction = (selector: string, keyCode: string, which: number) => {
+    return {
+        title: `key down ${keyCode}`,
+        execute: () => {
+            const target = window.document.querySelector(selector);
+            if (!target) {
+                throw new Error(`could not find ${selector}`);
+            }
+            target.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    code: keyCode,
+                    key: keyCode,
+                    bubbles: true,
+                    composed: true,
+                    which: which,
+                }),
+            );
+        },
+        timeout: 1000,
     };
 };
 

--- a/packages/components/src/hooks/use-keyboard-nav.ts
+++ b/packages/components/src/hooks/use-keyboard-nav.ts
@@ -1,136 +1,126 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { childrenById, KeyCodes } from '../common';
 
-export const useIdBasedKeyboardNav = (
+export const getHandleKeyboardNav = (
     elementsParent: React.RefObject<HTMLElement>,
     focusedId: string | undefined,
     setFocusedId: (id: string) => void,
-    selectedId: string | undefined,
-    setSelectedId: (id: string) => void
+    setSelectedId: (id: string) => void,
 ) => {
-    const onKeyPress = useCallback(
-        (ev: React.KeyboardEvent) => {
-            if (
-                ev.target instanceof HTMLInputElement ||
-                ev.target instanceof HTMLTextAreaElement ||
-                !focusedId ||
-                !elementsParent.current
-            ) {
-                return;
-            }
+    const onKeyPress = (ev: React.KeyboardEvent) => {
+        if (
+            ev.target instanceof HTMLInputElement ||
+            ev.target instanceof HTMLTextAreaElement ||
+            !focusedId ||
+            !elementsParent.current
+        ) {
+            return;
+        }
 
-            const element = elementsParent.current;
-            const children = childrenById(element);
-            const currentFocused = children[focusedId];
-            if (!currentFocused) {
-                return;
-            }
-            const gotoDir = (dir: 'up' | 'down' | 'left' | 'right') => {
-                const focusedRect = currentFocused.getBoundingClientRect();
-                let nextId: string | null = null;
-                let nextIdDistance = Number.MAX_SAFE_INTEGER;
-                let nextElement: Element | null = null;
-                const focusMiddle =
-                    dir === 'up'
-                        ? (focusedRect.top + focusedRect.height / 2) * -1
-                        : dir === 'down'
-                        ? focusedRect.top + focusedRect.height / 2
-                        : dir === 'left'
+        const element = elementsParent.current;
+        const children = childrenById(element);
+        const currentFocused = children[focusedId];
+        if (!currentFocused) {
+            return;
+        }
+        const gotoDir = (dir: 'up' | 'down' | 'left' | 'right') => {
+            const focusedRect = currentFocused.getBoundingClientRect();
+            let nextId: string | null = null;
+            let nextIdDistance = Number.MAX_SAFE_INTEGER;
+            let nextElement: Element | null = null;
+            const focusMiddle =
+                dir === 'up'
+                    ? (focusedRect.top + focusedRect.height / 2) * -1
+                    : dir === 'down'
+                      ? focusedRect.top + focusedRect.height / 2
+                      : dir === 'left'
                         ? (focusedRect.left + focusedRect.width / 2) * -1
                         : focusedRect.left + focusedRect.width / 2;
-                const focusLeft =
-                    dir === 'up'
-                        ? focusedRect.left
-                        : dir === 'down'
-                        ? focusedRect.left
-                        : dir === 'left'
+            const focusLeft =
+                dir === 'up'
+                    ? focusedRect.left
+                    : dir === 'down'
+                      ? focusedRect.left
+                      : dir === 'left'
                         ? focusedRect.top
                         : focusedRect.top;
-                const focusRight =
-                    dir === 'up'
-                        ? focusedRect.right
-                        : dir === 'down'
-                        ? focusedRect.right
-                        : dir === 'left'
+            const focusRight =
+                dir === 'up'
+                    ? focusedRect.right
+                    : dir === 'down'
+                      ? focusedRect.right
+                      : dir === 'left'
                         ? focusedRect.bottom
                         : focusedRect.bottom;
-                for (const [id, element] of Object.entries(children)) {
-                    if (id !== focusedId) {
-                        const rect = element.getBoundingClientRect();
-                        const rectStart =
-                            dir === 'up'
-                                ? rect.bottom * -1
-                                : dir === 'down'
-                                ? rect.top
-                                : dir === 'left'
+            for (const [id, element] of Object.entries(children)) {
+                if (id !== focusedId) {
+                    const rect = element.getBoundingClientRect();
+                    const rectStart =
+                        dir === 'up'
+                            ? rect.bottom * -1
+                            : dir === 'down'
+                              ? rect.top
+                              : dir === 'left'
                                 ? rect.right * -1
                                 : rect.left;
-                        const rectLeft =
-                            dir === 'up'
-                                ? rect.left
-                                : dir === 'down'
-                                ? rect.left
-                                : dir === 'left'
-                                ? rect.top
-                                : rect.top;
-                        const rectRight =
-                            dir === 'up'
-                                ? rect.right
-                                : dir === 'down'
-                                ? rect.right
-                                : dir === 'left'
+                    const rectLeft =
+                        dir === 'up' ? rect.left : dir === 'down' ? rect.left : dir === 'left' ? rect.top : rect.top;
+                    const rectRight =
+                        dir === 'up'
+                            ? rect.right
+                            : dir === 'down'
+                              ? rect.right
+                              : dir === 'left'
                                 ? rect.bottom
                                 : rect.bottom;
-                        if (rectStart > focusMiddle) {
-                            const distanceMain = rectStart - focusMiddle;
+                    if (rectStart > focusMiddle) {
+                        const distanceMain = rectStart - focusMiddle;
 
-                            const distanceSides = Math.max(
-                                Math.max(rectLeft - focusLeft, 0),
-                                Math.max(focusRight - rectRight, 0),
-                                0
-                            );
-                            const distance = Math.sqrt(Math.pow(distanceMain, 2) + Math.pow(distanceSides, 2));
-                            if (distance < nextIdDistance) {
-                                nextId = id;
-                                nextIdDistance = distance;
-                                nextElement = element;
-                            }
+                        const distanceSides = Math.max(
+                            Math.max(rectLeft - focusLeft, 0),
+                            Math.max(focusRight - rectRight, 0),
+                            0,
+                        );
+                        const distance = Math.sqrt(Math.pow(distanceMain, 2) + Math.pow(distanceSides, 2));
+                        if (distance < nextIdDistance) {
+                            nextId = id;
+                            nextIdDistance = distance;
+                            nextElement = element;
                         }
                     }
                 }
-                if (nextId) {
-                    setFocusedId(nextId);
-                    if (nextElement) {
-                        nextElement.scrollIntoView({
-                            behavior: 'smooth',
-                            inline: 'nearest',
-                            block: 'nearest',
-                        });
-                    }
-                }
-            };
-            switch (ev.code as KeyCodes) {
-                case KeyCodes.ArrowLeft: {
-                    gotoDir('left');
-                    break;
-                }
-                case KeyCodes.ArrowRight:
-                    gotoDir('right');
-                    break;
-                case KeyCodes.ArrowUp:
-                    gotoDir('up');
-                    break;
-                case KeyCodes.ArrowDown:
-                    gotoDir('down');
-                    break;
-                case KeyCodes.Space:
-                case KeyCodes.Enter:
-                    setSelectedId(focusedId);
-                    break;
-                default:
             }
-        },
-        [elementsParent, focusedId, setFocusedId, setSelectedId]
-    );
+            if (nextId) {
+                setFocusedId(nextId);
+                if (nextElement) {
+                    nextElement.scrollIntoView({
+                        behavior: 'smooth',
+                        inline: 'nearest',
+                        block: 'nearest',
+                    });
+                }
+            }
+        };
+        switch (ev.code as KeyCodes) {
+            case KeyCodes.ArrowLeft: {
+                gotoDir('left');
+                break;
+            }
+            case KeyCodes.ArrowRight:
+                gotoDir('right');
+                break;
+            case KeyCodes.ArrowUp:
+                gotoDir('up');
+                break;
+            case KeyCodes.ArrowDown:
+                gotoDir('down');
+                break;
+            case KeyCodes.Space:
+            case KeyCodes.Enter:
+                setSelectedId(focusedId);
+                break;
+            default:
+        }
+    };
     return onKeyPress;
 };

--- a/packages/components/src/hooks/use-tree-view-keyboard-interaction.ts
+++ b/packages/components/src/hooks/use-tree-view-keyboard-interaction.ts
@@ -59,13 +59,21 @@ export const useTreeViewKeyboardInteraction = ({
         (itemId: string | undefined) => {
             if (!itemId) return;
 
-            focus(itemId);
             if (selectionFollowsFocus) {
                 select(itemId, 'keyboard');
+            } else {
+                focus(itemId);
             }
         },
         [focus, select, selectionFollowsFocus],
     );
+
+    const selectFocused = useCallback(() => {
+        if (!focusedItemId) {
+            return;
+        }
+        select(focusedItemId);
+    }, [focusedItemId, select]);
 
     const handleArrowRight = useCallback(() => {
         if (!focusedItemId) return;
@@ -116,6 +124,8 @@ export const useTreeViewKeyboardInteraction = ({
                 [KeyCodes.ArrowDown]: handleArrowDown,
                 [KeyCodes.Home]: handleHome,
                 [KeyCodes.End]: handleEnd,
+                [KeyCodes.Space]: selectFocused,
+                [KeyCodes.Enter]: selectFocused,
             }[event.code];
             if (!handler) return;
 
@@ -123,7 +133,7 @@ export const useTreeViewKeyboardInteraction = ({
 
             handler();
         },
-        [handleArrowRight, handleArrowLeft, handleArrowUp, handleArrowDown, handleHome, handleEnd],
+        [handleArrowRight, handleArrowLeft, handleArrowUp, handleArrowDown, handleHome, handleEnd, selectFocused],
     );
 
     useEffect(() => {

--- a/packages/components/src/scroll-list/boards/scroll-ref.board.tsx
+++ b/packages/components/src/scroll-list/boards/scroll-ref.board.tsx
@@ -4,9 +4,7 @@ import { createItems, getId, ItemRenderer } from '../../board-assets';
 import {
     clickAction,
     expectElement,
-    expectElementsStyle,
     expectElementStyle,
-    hoverAction,
     projectThemesPlugin,
     scenarioPlugin,
     scrollAction,
@@ -63,19 +61,6 @@ export default createBoard({
             title: 'scroll list sanity',
             events: [
                 expectElement('[data-id="a3"]'),
-                hoverAction('[data-id="a3"]'),
-                expectElementStyle('[data-id="a3"]', {
-                    backgroundColor: 'rgb(173, 216, 230)',
-                }),
-                hoverAction('[data-id="a4"]'),
-                expectElementsStyle({
-                    '[data-id="a3"]': {
-                        backgroundColor: 'none',
-                    },
-                    '[data-id="a4"]': {
-                        backgroundColor: 'rgb(173, 216, 230)',
-                    },
-                }),
                 clickAction('[data-id="a4"]'),
                 expectElementStyle('[data-id="a4"]', {
                     backgroundColor: 'rgb(173, 216, 230)',

--- a/packages/components/src/scroll-list/scroll-list.tsx
+++ b/packages/components/src/scroll-list/scroll-list.tsx
@@ -157,6 +157,7 @@ export function ScrollList<T, EL extends HTMLElement = HTMLDivElement>({
     itemsInRow = 1,
     transmitKeyPress,
     overlay,
+    disableKeyboard,
 }: ScrollListProps<T, EL>): JSX.Element {
     const defaultScrollListRef = useRef<EL>();
     const scrollListRef = (scrollListRoot?.props?.ref as React.RefObject<HTMLElement>) || defaultScrollListRef;
@@ -309,6 +310,7 @@ export function ScrollList<T, EL extends HTMLElement = HTMLDivElement>({
                 focusControl={focusControlMemoized}
                 selectionControl={selectionControlMemoized}
                 transmitKeyPress={transmitKeyPress}
+                disableKeyboard={disableKeyboard}
             />
             {overlay ? (
                 <ListOverlaySlot

--- a/packages/components/src/tree/boards/tree-focus.board.tsx
+++ b/packages/components/src/tree/boards/tree-focus.board.tsx
@@ -1,0 +1,85 @@
+import { createBoard } from '@wixc3/react-board';
+import React, { useRef, useState } from 'react';
+import { Tree } from '../tree';
+import { TreeItemData } from '../../board-assets';
+import { TreeItemRenderer } from '../../board-assets/tree-items/tree-item-renderer';
+import {
+    clickAction,
+    expectElement,
+    expectElementStyle,
+    focusAction,
+    hoverAction,
+    keyDownAction,
+    scenarioPlugin,
+} from '../../board-plugins';
+import { KeyCodes } from '../../common';
+
+const data: TreeItemData = {
+    id: '1',
+    title: 'item 1',
+    children: [
+        { id: '2', title: 'item 2' },
+        { id: '3', title: 'item 3' },
+        { id: '4', title: 'item 4' },
+        { id: '5', title: 'item 5' },
+        { id: '6', title: 'item 6' },
+    ],
+};
+
+export default createBoard({
+    name: 'Tree Focus and Others',
+    Board: () => {
+        const openItemsControl = useState<string[]>([]);
+        const scrollRef = useRef<HTMLDivElement>(null);
+        const selectionControl = useState<string | undefined>();
+        return (
+            <div>
+                <Tree<typeof data>
+                    data={data}
+                    getId={(it) => it.id}
+                    ItemRenderer={TreeItemRenderer}
+                    getChildren={(it) => it.children || []}
+                    openItemsControls={openItemsControl}
+                    selectionControl={selectionControl}
+                    overlay={{ el: () => null, props: {} }}
+                    listRoot={{
+                        props: {
+                            ref: scrollRef,
+                            id: 'LIST',
+                        },
+                    }}
+                    eventRoots={[scrollRef]}
+                />
+                <button id="clear" onClick={() => selectionControl[1](undefined)}>
+                    clear selection
+                </button>
+                <button id="select" onClick={() => selectionControl[1]('5')}>
+                    select 5
+                </button>
+            </div>
+        );
+    },
+    plugins: [
+        scenarioPlugin.use({
+            title: 'tree focus should follow select and not hover',
+            events: [
+                clickAction('[data-id="1"]'),
+                keyDownAction('[data-id="1"]', KeyCodes.ArrowRight, 39),
+                expectElement('[data-id="2"]'),
+                hoverAction('[data-id="3"]'),
+                keyDownAction('[data-id="1"]', KeyCodes.ArrowDown, 40),
+                expectElementStyle('[data-id="2"]', { color: 'rgb(0, 0, 255)' }), //blue (focused)
+                clickAction('#clear'),
+                expectElementStyle('[data-id="2"]', { color: 'rgb(0, 0, 0)' }), //black (not focused)
+                clickAction('#select'),
+                focusAction('#LIST'),
+                keyDownAction('[data-id="5"]', KeyCodes.ArrowDown, 40),
+                expectElementStyle('[data-id="6"]', { color: 'rgb(0, 0, 255)' }), //blue (focused)
+            ],
+        }),
+    ],
+    environmentProps: {
+        windowWidth: 600,
+        windowHeight: 400,
+    },
+});

--- a/packages/components/src/tree/boards/tree-keyboard.board.tsx
+++ b/packages/components/src/tree/boards/tree-keyboard.board.tsx
@@ -1,0 +1,68 @@
+import { createBoard } from '@wixc3/react-board';
+import React, { useRef, useState } from 'react';
+import { Tree } from '../tree';
+import { TreeItemData } from '../../board-assets';
+import { TreeItemRenderer } from '../../board-assets/tree-items/tree-item-renderer';
+import { clickAction, expectElement, expectElementStyle, keyDownAction, scenarioPlugin } from '../../board-plugins';
+import { KeyCodes } from '../../common';
+
+const data: TreeItemData = {
+    id: '1',
+    title: 'item 1',
+    children: [
+        { id: '2', title: 'item 2' },
+        { id: '3', title: 'item 3' },
+        { id: '4', title: 'item 4' },
+        { id: '5', title: 'item 5' },
+        { id: '6', title: 'item 6' },
+    ],
+};
+
+export default createBoard({
+    name: 'Tree Keyboard',
+    Board: () => {
+        const openItemsControl = useState<string[]>([]);
+        const scrollRef = useRef<HTMLDivElement>(null);
+        return (
+            <Tree<typeof data>
+                data={data}
+                getId={(it) => it.id}
+                ItemRenderer={TreeItemRenderer}
+                getChildren={(it) => it.children || []}
+                openItemsControls={openItemsControl}
+                overlay={{ el: () => null, props: {} }}
+                listRoot={{
+                    props: {
+                        ref: scrollRef,
+                        id: 'LIST',
+                    },
+                }}
+                eventRoots={[scrollRef]}
+            />
+        );
+    },
+    plugins: [
+        scenarioPlugin.use({
+            title: 'tree focus test',
+            events: [
+                clickAction('[data-id="1"]'),
+                keyDownAction('#LIST', KeyCodes.ArrowRight, 39),
+                expectElement('[data-id="2"]'),
+                keyDownAction('[data-id="1"]', KeyCodes.ArrowDown, 40),
+                expectElementStyle('[data-id="2"]', { color: 'rgb(0, 0, 255)' }), //blue (focused)
+                keyDownAction('[data-id="2"]', KeyCodes.Space, 32),
+                expectElementStyle('[data-id="2"]', { textDecorationLine: 'underline' }),
+                keyDownAction('[data-id="2"]', KeyCodes.Home, 36),
+                expectElementStyle('[data-id="1"]', { color: 'rgb(0, 0, 255)' }), //blue (focused)
+                keyDownAction('[data-id="1"]', KeyCodes.End, 35),
+                expectElementStyle('[data-id="6"]', { color: 'rgb(0, 0, 255)' }), //blue (focused)
+                keyDownAction('[data-id="6"]', KeyCodes.Enter, 13),
+                expectElementStyle('[data-id="6"]', { textDecorationLine: 'underline' }), //selected
+            ],
+        }),
+    ],
+    environmentProps: {
+        windowWidth: 600,
+        windowHeight: 400,
+    },
+});

--- a/packages/components/src/tree/tree.tsx
+++ b/packages/components/src/tree/tree.tsx
@@ -15,7 +15,7 @@ const treeWrapperContext = createContext<TreeWrapperContext>({
 });
 
 export const TreeItemWrapper = <T,>(
-    UserRenderer: React.ComponentType<TreeItemProps<T>>
+    UserRenderer: React.ComponentType<TreeItemProps<T>>,
 ): ((props: ListItemProps<T>) => JSX.Element) => {
     const Wrapper = (props: ListItemProps<T>) => {
         const { openItemIds, close, open, getChildren, getDepth } = useContext(treeWrapperContext);
@@ -57,22 +57,23 @@ export function Tree<T, EL extends HTMLElement = HTMLElement>(props: TreeProps<T
     } = props;
     const [openItemIds, setOpenItemIds] = useStateControls(openItemsControls, []);
     const [focusedItemId, focus] = useStateControls(focusControl, undefined);
-    const [, select] = useStateControls(scrollListProps.selectionControl, undefined);
+    const [selectedId, select] = useStateControls(scrollListProps.selectionControl, undefined);
+
     const { items, treeItemDepths } = useMemo(
         () => getItems({ item: data, getChildren, getId, openItemIds }),
-        [data, getChildren, getId, openItemIds]
+        [data, getChildren, getId, openItemIds],
     );
     const treeItems = useMemo(() => getAllTreeItems({ item: data, getChildren, getId }), [data, getChildren, getId]);
 
     const getParent = useCallback(
         (itemId: string) => {
             const parent = treeItems.find((potentialParent) =>
-                getChildren(potentialParent).some((item) => getId(item) === itemId)
+                getChildren(potentialParent).some((item) => getId(item) === itemId),
             );
 
             return parent && getId(parent);
         },
-        [getChildren, getId, treeItems]
+        [getChildren, getId, treeItems],
     );
 
     const getFirstChild = useCallback(
@@ -83,7 +84,7 @@ export function Tree<T, EL extends HTMLElement = HTMLElement>(props: TreeProps<T
 
             return firstChild && getId(firstChild);
         },
-        [getChildren, getId, treeItems]
+        [getChildren, getId, treeItems],
     );
 
     const isEndNode = useCallback(
@@ -93,7 +94,7 @@ export function Tree<T, EL extends HTMLElement = HTMLElement>(props: TreeProps<T
 
             return children?.length === 0;
         },
-        [getChildren, getId, treeItems]
+        [getChildren, getId, treeItems],
     );
 
     const isOpen = useCallback((itemId: string) => openItemIds.includes(itemId), [openItemIds]);
@@ -108,7 +109,7 @@ export function Tree<T, EL extends HTMLElement = HTMLElement>(props: TreeProps<T
 
             return prevItem ? getId(prevItem) : undefined;
         },
-        [items, getId]
+        [items, getId],
     );
 
     const getNext = useCallback(
@@ -119,7 +120,7 @@ export function Tree<T, EL extends HTMLElement = HTMLElement>(props: TreeProps<T
 
             return nextItem ? getId(nextItem) : undefined;
         },
-        [items, getId]
+        [items, getId],
     );
 
     const getFirst = useCallback(() => {
@@ -140,7 +141,7 @@ export function Tree<T, EL extends HTMLElement = HTMLElement>(props: TreeProps<T
                 setOpenItemIds([...openItemIds, id]);
             }
         },
-        [isOpen, openItemIds, setOpenItemIds]
+        [isOpen, openItemIds, setOpenItemIds],
     );
 
     const close = useCallback(
@@ -149,7 +150,7 @@ export function Tree<T, EL extends HTMLElement = HTMLElement>(props: TreeProps<T
                 setOpenItemIds(openItemIds.filter((itemId) => itemId !== id));
             }
         },
-        [isOpen, openItemIds, setOpenItemIds]
+        [isOpen, openItemIds, setOpenItemIds],
     );
 
     useTreeViewKeyboardInteraction({
@@ -207,7 +208,9 @@ export function Tree<T, EL extends HTMLElement = HTMLElement>(props: TreeProps<T
                 ItemRenderer={itemRenderer}
                 listRoot={listRoot}
                 focusControl={[focusedItemId, focus]}
+                selectionControl={[selectedId, select]}
                 itemSize={listItemSize}
+                disableKeyboard={true}
             />
         </treeWrapperContext.Provider>
     );


### PR DESCRIPTION
make focus follow selection and not hover
let tree keyboard handling override the list

FYI:
it will be nice to refactor this lib..
1. it doesn't memo anything, except icons, so we can delete all the `useCallback`s
2. it should probably use `react-window` since it is already used in codux and probably Radix `Slot` and maybe other things
3. it all could be smaller and simpler :)
4. I'd really prefer to write tests the traditional way, using an existing library :)